### PR TITLE
Use max instead of mean-of-sum for pair_chains iptm calculation

### DIFF
--- a/boltz_ph/pipeline.py
+++ b/boltz_ph/pipeline.py
@@ -443,11 +443,10 @@ class ProteinHunter_Boltz:
         # Calculate i-pTM
         if len(pair_chains) > 1:
             values = [
-                (
-                    pair_chains[binder_chain_idx][i].detach().cpu().numpy()
-                    + pair_chains[i][binder_chain_idx].detach().cpu().numpy()
+                max(
+                    pair_chains[binder_chain_idx][i].detach().cpu().numpy(),
+                    pair_chains[i][binder_chain_idx].detach().cpu().numpy()
                 )
-                / 2.0
                 for i in range(len(pair_chains))
                 if i != binder_chain_idx
             ]
@@ -520,11 +519,10 @@ class ProteinHunter_Boltz:
             pair_chains = output["pair_chains_iptm"]
             if len(pair_chains) > 1:
                 values = [
-                    (
-                        pair_chains[current_chain_idx][i].detach().cpu().numpy()
-                        + pair_chains[i][current_chain_idx].detach().cpu().numpy()
+                    max(
+                        pair_chains[current_chain_idx][i].detach().cpu().numpy(),
+                        pair_chains[i][current_chain_idx].detach().cpu().numpy()
                     )
-                    / 2.0
                     for i in range(len(pair_chains))
                     if i != current_chain_idx
                 ]


### PR DESCRIPTION
  **Use max instead of / 2.0 for pair_chains iPTM calculation**
  
  Previously, the inter-chain iPTM score between the binder and each target chain was computed as the average of the
  two directional scores:  (pair_chains[binder_idx][i] + pair_chains[i][binder_idx]) / 2.0

  This can underestimate binding confidence when the two directional scores are asymmetric (e.g. small molecule) . This PR changes the aggregation to take the maximum of the two values instead:   max(pair_chains[binder_idx][i], pair_chains[i][binder_idx])
